### PR TITLE
Trello-style horizontal scroll for meal plan calendar

### DIFF
--- a/packages/web/src/pages/MealPlan.tsx
+++ b/packages/web/src/pages/MealPlan.tsx
@@ -359,6 +359,8 @@ export default function MealPlan() {
       const scrollLeft = col.offsetLeft - grid.offsetLeft - (grid.clientWidth / 2) + (col.offsetWidth / 2)
       grid.scrollTo({ left: Math.max(0, scrollLeft), behavior: 'smooth' })
     }
+  // entriesLoading is intentional: the grid ref isn't mounted while loading,
+  // so we re-run this effect once data arrives and the real grid renders.
   }, [weekParam, isMobile, entriesLoading])
 
   const getEntriesForSlot = (date: Date, mealType: MealType): MealPlanEntry[] => {
@@ -998,6 +1000,7 @@ const styles: Record<string, React.CSSProperties> = {
     paddingBottom: '0.5rem',
     scrollbarWidth: 'thin',
     scrollbarColor: `${colors.border} transparent`,
+    position: 'relative',
   },
   dayColumn: {
     display: 'flex',


### PR DESCRIPTION
## Summary
- Changed meal plan calendar from cramped 7-column grid to Trello-style horizontal scroll with fixed-width (220px) day columns
- Only ~4 days visible at a time, giving each column enough room for readable recipe names
- Auto-scrolls to center today's column on load and week changes
- Recipe names now wrap up to 2 lines instead of truncating with ellipsis

## Motivation
With 7 columns forced into the viewport, recipe names were cut off after a few characters, making the calendar unusable for identifying meals at a glance.

## Test plan
- [ ] Verify ~4 day columns visible on a standard desktop viewport
- [ ] Scroll horizontally to see all 7 days
- [ ] Confirm today's column is centered on page load
- [ ] Navigate to a different week and back — verify auto-scroll still works
- [ ] Check recipe names wrap to 2 lines instead of truncating
- [ ] Test on mobile — should still use the card layout (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)