### PR TITLE
Add copy previous week feature for meal plans

### DIFF
--- a/packages/api/src/lib/validators.ts
+++ b/packages/api/src/lib/validators.ts
@@ -20,6 +20,11 @@ export const patchMealPlanSchema = z.object({
   sortOrder: z.number().int().min(0),
 })
 
+export const copyWeekSchema = z.object({
+  sourceWeekStart: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD'),
+  targetWeekStart: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD'),
+})
+
 // ── Grocery Lists ───────────────────────────────────────────
 export const createGroceryListSchema = z.object({
   name: z.string().min(1, 'Name is required').trim(),

--- a/packages/api/src/routes/meal-plans.ts
+++ b/packages/api/src/routes/meal-plans.ts
@@ -4,7 +4,7 @@ import { db } from '../db'
 import { mealPlans, recipes } from '../db/schema'
 import { getSession, getUserWithHousehold } from '../lib/auth-helpers'
 import { getWeekStartMonday } from '../lib/dates'
-import { validate, createMealPlanSchema, patchMealPlanSchema } from '../lib/validators'
+import { validate, createMealPlanSchema, patchMealPlanSchema, copyWeekSchema } from '../lib/validators'
 
 const mealPlansRouter = new Hono()
 
@@ -149,6 +149,76 @@ mealPlansRouter.post('/', async (c) => {
     },
     201
   )
+})
+
+// POST /copy-week - Copy all entries from one week to another
+mealPlansRouter.post('/copy-week', async (c) => {
+  const session = await getSession(c)
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
+
+  const currentUser = await getUserWithHousehold(session.user.id)
+  if (!currentUser?.householdId) {
+    return c.json({ error: 'You must be in a household' }, 400)
+  }
+
+  const body = await c.req.json()
+  const parsed = validate(copyWeekSchema, body)
+  if (!parsed.success) {
+    return c.json({ error: parsed.error }, 400)
+  }
+  const { sourceWeekStart, targetWeekStart } = parsed.data
+
+  if (sourceWeekStart === targetWeekStart) {
+    return c.json({ error: 'Source and target weeks must be different' }, 400)
+  }
+
+  const sourceStart = new Date(sourceWeekStart + 'T00:00:00Z')
+  const sourceEnd = new Date(sourceStart)
+  sourceEnd.setUTCDate(sourceEnd.getUTCDate() + 7)
+
+  const targetStart = new Date(targetWeekStart + 'T00:00:00Z')
+
+  // Fetch source week entries
+  const sourceEntries = await db
+    .select()
+    .from(mealPlans)
+    .where(
+      and(
+        eq(mealPlans.householdId, currentUser.householdId),
+        gte(mealPlans.date, sourceStart),
+        lt(mealPlans.date, sourceEnd)
+      )
+    )
+    .orderBy(asc(mealPlans.date), asc(mealPlans.mealType), asc(mealPlans.sortOrder))
+
+  if (sourceEntries.length === 0) {
+    return c.json({ error: 'No entries found in the source week' }, 400)
+  }
+
+  // Create new entries with offset dates
+  const newEntries = sourceEntries.map((entry) => {
+    const dayOffset = Math.floor(
+      (entry.date.getTime() - sourceStart.getTime()) / (1000 * 60 * 60 * 24)
+    )
+    const targetDate = new Date(targetStart)
+    targetDate.setUTCDate(targetDate.getUTCDate() + dayOffset)
+
+    return {
+      householdId: currentUser.householdId!,
+      recipeId: entry.recipeId,
+      date: targetDate,
+      mealType: entry.mealType,
+      sortOrder: entry.sortOrder,
+      createdByUserId: session.user.id,
+      updatedByUserId: session.user.id,
+    }
+  })
+
+  await db.insert(mealPlans).values(newEntries)
+
+  return c.json({ data: { copiedCount: newEntries.length } }, 201)
 })
 
 // PATCH /:id - Move a meal plan entry (drag-and-drop)

--- a/packages/web/src/pages/MealPlan.tsx
+++ b/packages/web/src/pages/MealPlan.tsx
@@ -265,6 +265,27 @@ export default function MealPlan() {
     },
   })
 
+  const copyWeekMutation = useMutation({
+    mutationFn: (args: { sourceWeekStart: string; targetWeekStart: string }) =>
+      apiPost<{ copiedCount: number }>('/api/meal-plans/copy-week', args),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.mealPlanEntries(weekParam) })
+    },
+    onError: (err: Error) => {
+      setError(err.message || 'Failed to copy week')
+    },
+  })
+
+  const handleCopyPreviousWeek = () => {
+    const prevMonday = new Date(weekStart)
+    prevMonday.setDate(prevMonday.getDate() - 7)
+    setError('')
+    copyWeekMutation.mutate({
+      sourceWeekStart: formatDateParam(prevMonday),
+      targetWeekStart: weekParam,
+    })
+  }
+
   const [activeEntry, setActiveEntry] = useState<MealPlanEntry | null>(null)
 
   const sensors = useSensors(
@@ -480,6 +501,18 @@ export default function MealPlan() {
               )}
             </div>
             <div style={styles.headerActions}>
+              <button
+                onClick={handleCopyPreviousWeek}
+                className="btn-secondary"
+                style={styles.groceryButton}
+                disabled={copyWeekMutation.isPending}
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                  <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+                </svg>
+                {copyWeekMutation.isPending ? 'Copying...' : 'Copy Previous Week'}
+              </button>
               {weekRecipeIds.length > 0 && (
                 <button
                   onClick={handleCreateGroceryList}


### PR DESCRIPTION
## Summary
- New `POST /api/meal-plans/copy-week` endpoint that copies all meal plan entries from a source week to a target week
- "Copy Previous Week" button in the meal plan header UI
- Entries are additive — existing meals in the target week are preserved
- Button shows loading state ("Copying...") during the operation

## Details
- Backend validates source ≠ target, checks household authorization, and preserves day-of-week offset, meal type, and sort order
- `copyWeekSchema` Zod validator added for the new endpoint
- Frontend uses TanStack Query mutation with automatic cache invalidation on success

## Test plan
- [ ] Navigate to an empty week, click "Copy Previous Week" — verify entries from prior week appear
- [ ] Verify copied entries have correct day-of-week mapping (Monday→Monday, etc.)
- [ ] Verify meal types are preserved (breakfast stays breakfast, etc.)
- [ ] Click "Copy Previous Week" when prior week is empty — verify error message
- [ ] Verify existing entries in target week are not removed
- [ ] Button shows "Copying..." while request is in-flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)